### PR TITLE
fix intergration_test.go

### DIFF
--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -478,7 +478,7 @@ func setupLibrary(
 			t.Fail()
 		}
 
-		time.Sleep(time.Millisecond * 10)
+		time.Sleep(time.Millisecond * 100)
 	}
 
 	return cmd


### PR DESCRIPTION
Пофиксил некорректное время, до повторения http health check в integration_test.go