### PR TITLE
Added test to check authors<->books consistency

### DIFF
--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -425,7 +425,7 @@ func TestLibraryWithInMemoryInvariant(t *testing.T) {
 				}
 
 				for range iterations {
-					_, err = client.UpdateBook(ctx, &UpdateBookRequest{
+					_, err := client.UpdateBook(ctx, &UpdateBookRequest{
 						Id:        book.GetId(),
 						Name:      book.GetName(),
 						AuthorIds: newAuthorIds,

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -329,6 +329,8 @@ func TestLibraryWithInMemoryInvariant(t *testing.T) {
 		require.Equal(t, codes.NotFound, s.Code())
 	})
 
+	// placeholder for a new test
+
 	t.Run("book invalid argument", func(t *testing.T) {
 		ctx := context.Background()
 		client := newGRPCClient(t, grpcPort)


### PR DESCRIPTION
Test 1 explanation:

1) AddBookRequest, author_ids=[1, 2]
2) UpdateBookRequest, author_ids=[1]
3) GetAuthorBooksRequest, author_id = 2 // response should be empty

Test 2 explanation:

Parallel UpdateBook requests can break consistency if independent locks for books and authors are used and if only one lock is used at each moment.

1) AddBookRequest, author_ids=[1,2,..n]
2) many parallel UpdateBookRequests, author_ids=subset([1,2,..n])
3) GetBookInfo
4) Check if GetAuthorBooks responses for all authors are consistent with step 3

Proof that all tests can be passed here:
https://github.com/itmo-org/ctgo-library-service-letstatt/pull/2